### PR TITLE
Add generic header() function

### DIFF
--- a/lib/Bailador.pm
+++ b/lib/Bailador.pm
@@ -57,7 +57,7 @@ sub content_type(Str $type) is export {
 }
 
 sub header(Str $name, Cool $value) is export {
-    $app.response.headers{$name} = $value;
+    $app.response.headers{$name} = ~$value;
 }
 
 sub status(Int $code) is export {


### PR DESCRIPTION
Currently, there is no way to add arbitrary HTTP headers (such as `Location`). This patch will add one.
