### PR TITLE
bugfix - request.params<content> is empty

### DIFF
--- a/lib/Bailador/Request.pm
+++ b/lib/Bailador/Request.pm
@@ -8,7 +8,7 @@ class Bailador::Request {
         return {} unless $!env<psgi.input>;
         my $input = $!env<psgi.input>.decode;
 
-        %ret<content> = $input;
+        %ret<&content> = $input;
 
         for $input.split('&') -> $p {
             my $pair = $p.split('=', 2);


### PR DESCRIPTION
bugfix - request.params<content> wont be empty anymore (if a content is passed :) )
