### PR TITLE
bind to all interfaces, as advertised

### DIFF
--- a/lib/Bailador.pm
+++ b/lib/Bailador.pm
@@ -106,7 +106,7 @@ sub dispatch-psgi($env) {
 }
 
 sub baile($port = 3000) is export {
-    given HTTP::Easy::PSGI.new(:$port) {
+    given HTTP::Easy::PSGI.new(:host<0.0.0.0>, :$port) {
         .app(&dispatch-psgi);
         say "Entering the development dance floor: http://0.0.0.0:$port";
         .run;


### PR DESCRIPTION
I need this for Heroku deployments to work "out of the box". I think binding to all interfaces is the normal default for servers like this.

Currenly HTTP::Easy defaults to "localhost", but I opened a PR open there too.
