### PR TITLE
remove @*ARGS usage

### DIFF
--- a/lib/Bailador/App.pm
+++ b/lib/Bailador/App.pm
@@ -82,10 +82,7 @@ class Bailador::App is Bailador::Route {
     multi method baile() {
         my $command;
         my @params;
-        if @*ARGS.elems > 0 {
-            $command = @*ARGS.shift;
-            @params =  @*ARGS;
-        } elsif $.config.default-command() {
+        if $.config.default-command() {
             $command = $.config.default-command();
         } elsif $.config.command-detection() {
             $command = $.commands.detect-command();


### PR DESCRIPTION
This is an initial step for refactoring the @*ARGS usage / moving to bin/bailador (#148). Before modifying bin/bailador and converting args to $*ENV I want to understand more clearly how this is intended to be used.