### PR TITLE
List routes

### DIFF
--- a/bin/bailador
+++ b/bin/bailador
@@ -48,3 +48,7 @@ multi sub MAIN ('watch', Str $app, Str :$w = 'lib,bin', Str :$config) {
 multi sub MAIN ('easy', Str $app, Str :$config) {
     bootup-file('easy', $app, $config);
 }
+
+multi sub MAIN ('routes', Str $app, Str :$config) {
+    bootup-file('routes', $app, $config);
+}

--- a/lib/Bailador/CLI.pm
+++ b/lib/Bailador/CLI.pm
@@ -97,6 +97,13 @@ my multi sub bootup-file ('watch', Str $app, Str $w, Str $config?) is export {
     bootup-file($app);
 }
 
+my multi sub bootup-file ('routes', Str $app, Str $config?) is export {
+    my $param = ($config.defined ?? $config !! %*ENV<BAILADOR>);
+    $param ~= ',default-command:routes';
+    %*ENV<BAILADOR> = $param;
+    bootup-file($app);
+}
+
 multi sub bootup-file (Str $app) {
     say "Attempting to boot up the app";
     my @includes = repo-to-includes();

--- a/lib/Bailador/Command/routes.pm
+++ b/lib/Bailador/Command/routes.pm
@@ -5,7 +5,8 @@ use Bailador::Command;
 class Bailador::Command::routes does Bailador::Command {
     method run(:$app) {
         for $app.routes -> $r {
-            put join " ", $r.method.fmt("%10s"), $r.path-str // $r.^name;
+            my $path = $r.path-str // do { $r.^methods(:local).grep(*.name eq 'Str') && $r.Str } // $r.^name;
+            put join " ", $r.method.fmt("%10s"), $path;
         }
     }
 }

--- a/lib/Bailador/Command/routes.pm
+++ b/lib/Bailador/Command/routes.pm
@@ -1,0 +1,11 @@
+use v6;
+
+use Bailador::Command;
+
+class Bailador::Command::routes does Bailador::Command {
+    method run(:$app) {
+        for $app.routes -> $r {
+            say "$r.method.fmt("%10s")  {$r.path-str}";
+        }
+    }
+}

--- a/lib/Bailador/Command/routes.pm
+++ b/lib/Bailador/Command/routes.pm
@@ -5,7 +5,7 @@ use Bailador::Command;
 class Bailador::Command::routes does Bailador::Command {
     method run(:$app) {
         for $app.routes -> $r {
-            say "$r.method.fmt("%10s")  {$r.path-str}";
+            put join " ", $r.method.fmt("%10s"), $r.path-str // $r.^name;
         }
     }
 }

--- a/lib/Bailador/Route.pm
+++ b/lib/Bailador/Route.pm
@@ -30,16 +30,16 @@ class Bailador::Route {
         }).join("'/'");
     }
 
-    multi submethod new(Str @method, Regex $path, Callable $code, Str $path-str) {
+    multi submethod new(Str @method, Regex $path, Callable $code, Str $path-str = $path.perl) {
         self.bless(:@method, :$path, :$code, :$path-str);
     }
-    multi submethod new(Str $method, Regex $path, Callable $code, Str $path-str) {
+    multi submethod new(Str $method, Regex $path, Callable $code, Str $path-str = $path.perl) {
         my Str @methods = $method eq 'ANY'
         ?? <GET PUT POST HEAD PUT DELETE TRACE OPTIONS CONNECT PATCH>
         !! ($method);
         self.new(@methods, $path, $code, $path-str);
     }
-    multi submethod new(Str $method, Str $path, Callable $code, Str $path-str) {
+    multi submethod new(Str $method, Str $path, Callable $code, Str $path-str = $path) {
         my $regex = "/ ^ " ~ route_to_regex($path) ~ " [ \$ || <?before '/' > ] /";
         self.new($method, $regex.EVAL, $code, $path-str);
     }

--- a/lib/Bailador/Route/StaticFile.pm
+++ b/lib/Bailador/Route/StaticFile.pm
@@ -16,4 +16,8 @@ class Bailador::Route::StaticFile is Bailador::Route {
         return $file if $file.f;
         return False;
     }
+
+    method Str() {
+        "{self.^name} $.directory"
+    }
 }


### PR DESCRIPTION
This should take care of #138.

Store the original path with each route and provide a Bailador::Command for listing them.  Also provide a way for specific route types that may not have a `$.path-str` to modify how they appear in the output by defining their own `Str` method.

For example, from within the Bailador working dir:
```
➤ perl6 -Ilib bin/bailador routes examples/app.pl6 
Attempting to boot up the app
#        GET "/"
#        GET "/red"
#        GET "/die"
#        GET "/about"
#        GET "/hello/:name"
#        GET "/info"
#        GET /foo(.+)/
#        GET rx{ '/' (.+) '-' (.+) }
#        GET / ^ '/template/' (.+) $ /
#        GET "/env"
#        GET Bailador::Route::StaticFile /home/duff/repo/Bailador/examples/public

```