### PR TITLE
List prefix routes

### DIFF
--- a/examples/app.pl6
+++ b/examples/app.pl6
@@ -73,7 +73,7 @@ get '/env' => sub {
 app.add_route: Bailador::Route::StaticFile.new: directory => $?FILE.IO.parent.child('public'), path => / (.*) /;
 
 prefix '/media' => sub {
-    prefix '/video' => sub { 
+    prefix '/video' => sub {
         get '/dvds' => sub { 'DVDS' }
         get '/VHS'  => sub { 'VHS' }
     }

--- a/examples/app.pl6
+++ b/examples/app.pl6
@@ -72,4 +72,17 @@ get '/env' => sub {
 
 app.add_route: Bailador::Route::StaticFile.new: directory => $?FILE.IO.parent.child('public'), path => / (.*) /;
 
+prefix '/media' => sub {
+    prefix '/video' => sub { 
+        get '/dvds' => sub { 'DVDS' }
+        get '/VHS'  => sub { 'VHS' }
+    }
+    prefix '/music' => sub {
+        get '/cds'  => sub { 'CDS' }
+        get '/mp3'  => sub { 'MP3' }
+    }
+    get '/art'      => sub { 'art' }
+    get '/movies'   => sub { 'movies' }
+}
+
 baile();

--- a/lib/Bailador/Command/routes.pm
+++ b/lib/Bailador/Command/routes.pm
@@ -11,12 +11,12 @@ class Bailador::Command::routes does Bailador::Command {
             my $path = $prefix ~ ($r.path-str //
                                   do { $r.can('Str').[0].package.perl ne 'Mu' && $r.Str() } //
                                   $r.^name);
-            if $r.routes > 0 { 
+            if $r.routes > 0 {
                 print-routes($path, $r.routes);
             } else {
-                # because we've concatenated .perl strings, 
+                # because we've concatenated .perl strings,
                 # get rid of the doubled "" in the middle
-                $path ~~ s:g/'""'//;    
+                $path ~~ s:g/'""'//;
                 for $r.method.list -> $method {
                     put join " ", $method.fmt("%10s"), $path;
                 }

--- a/lib/Bailador/Command/routes.pm
+++ b/lib/Bailador/Command/routes.pm
@@ -3,10 +3,28 @@ use v6;
 use Bailador::Command;
 
 class Bailador::Command::routes does Bailador::Command {
-    method run(:$app) {
-        for $app.routes -> $r {
-            my $path = $r.path-str // do { $r.^methods(:local).grep(*.name eq 'Str') && $r.Str } // $r.^name;
-            put join " ", $r.method.fmt("%10s"), $path;
+    sub print-routes($prefix,@routes) {
+        for @routes -> $r {
+            # Try to combine the prefix and .path-str
+            # If we don't have a .path-str, call .Str unless it was inherited from Mu
+            # otherwise just output the name of the Route class
+            my $path = $prefix ~ ($r.path-str //
+                                  do { $r.can('Str').[0].package.perl ne 'Mu' && $r.Str() } //
+                                  $r.^name);
+            if $r.routes > 0 { 
+                print-routes($path, $r.routes);
+            } else {
+                # because we've concatenated .perl strings, 
+                # get rid of the doubled "" in the middle
+                $path ~~ s:g/'""'//;    
+                for $r.method.list -> $method {
+                    put join " ", $method.fmt("%10s"), $path;
+                }
+            }
         }
+    }
+
+    method run(:$app) {
+        print-routes('',$app.routes);
     }
 }

--- a/lib/Bailador/Route.pm
+++ b/lib/Bailador/Route.pm
@@ -39,7 +39,7 @@ class Bailador::Route {
         !! ($method);
         self.new(@methods, $path, $code, $path-str);
     }
-    multi submethod new(Str $method, Str $path, Callable $code, Str $path-str = $path) {
+    multi submethod new(Str $method, Str $path, Callable $code, Str $path-str = $path.perl) {
         my $regex = "/ ^ " ~ route_to_regex($path) ~ " [ \$ || <?before '/' > ] /";
         self.new($method, $regex.EVAL, $code, $path-str);
     }


### PR DESCRIPTION
An update to include prefix routes as part of the output.  The output of the updated example program, that now includes prefixes, looks like this:
```
➤ perl6 -Ilib bin/bailador routes examples/app.pl6 
Attempting to boot up the app
#        GET "/"
#        GET "/red"
#        GET "/die"
#        GET "/about"
#        GET "/hello/:name"
#        GET "/info"
#        GET /foo(.+)/
#        GET rx{ '/' (.+) '-' (.+) }
#        GET / ^ '/template/' (.+) $ /
#        GET "/env"
#        GET Bailador::Route::StaticFile /home/duff/repo/Bailador/examples/public
#        GET "/media/video/dvds"
#        GET "/media/video/VHS"
#        GET "/media/music/cds"
#        GET "/media/music/mp3"
#        GET "/media/art"
#        GET "/media/movies"
```