### PR TITLE
conventional imports

### DIFF
--- a/lib/Bailador.pm
+++ b/lib/Bailador.pm
@@ -1,8 +1,10 @@
 use v6.c;
+
+use HTTP::Easy::PSGI;
+
 use Bailador::App;
 use Bailador::Request;
 use Bailador::Template;
-use HTTP::Easy::PSGI;
 
 unit module Bailador;
 

--- a/lib/Bailador/App.pm
+++ b/lib/Bailador/App.pm
@@ -1,16 +1,18 @@
-use v6;
+use v6.c;
 
-use Bailador::Context;
-use Bailador::Route;
-use Bailador::Template::Mojo;
-use Bailador::Sessions;
-use Bailador::Exceptions;
-use Bailador::ContentTypes;
+use Log::Any;
+use Template::Mojo;
+
 use Bailador::Configuration;
 use Bailador::Commands;
+use Bailador::ContentTypes;
+use Bailador::Context;
+use Bailador::Exceptions;
 use Bailador::LogAdapter;
-use Template::Mojo;
-use Log::Any;
+use Bailador::Route;
+use Bailador::Sessions;
+use Bailador::Template::Mojo;
+
 
 class Bailador::App is Bailador::Route {
     has Str $.location is rw = '.';

--- a/lib/Bailador/CLI.pm
+++ b/lib/Bailador/CLI.pm
@@ -5,7 +5,7 @@ unit module Bailador::CLI;
 sub skeleton() is export {
     my %skeleton;
 %skeleton{'bin/app.pl6'} =
-q{use v6;
+q{use v6.c;
 use Bailador;
 Bailador::import();
 
@@ -19,7 +19,7 @@ baile();
 };
 
 %skeleton{'t/app.t'} =
-q{use v6;
+q{use v6.c;
 use Test;
 use Bailador::Test;
 
@@ -111,4 +111,3 @@ sub repo-to-includes is export {
     }
     return @includes;
 }
-

--- a/lib/Bailador/Command.pm
+++ b/lib/Bailador/Command.pm
@@ -1,4 +1,4 @@
-use v6;
+use v6.c;
 
 role Bailador::Command {
     method run(:$app) { ... }

--- a/lib/Bailador/Command/easy.pm
+++ b/lib/Bailador/Command/easy.pm
@@ -1,7 +1,8 @@
-use v6;
+use v6.c;
+
+use HTTP::Easy::PSGI;
 
 use Bailador::Command;
-use HTTP::Easy::PSGI;
 
 class Bailador::Command::easy does Bailador::Command {
     method run(:$app) {

--- a/lib/Bailador/Command/ogre.pm
+++ b/lib/Bailador/Command/ogre.pm
@@ -1,7 +1,8 @@
-use v6;
+use v6.c;
+
+use HTTP::Server::Ogre;
 
 use Bailador::Command;
-use HTTP::Server::Ogre;
 
 class Bailador::Command::ogre does Bailador::Command {
     method run(:$app) {

--- a/lib/Bailador/Command/p6w.pm
+++ b/lib/Bailador/Command/p6w.pm
@@ -1,4 +1,4 @@
-use v6;
+use v6.c;
 
 use Bailador::Command;
 

--- a/lib/Bailador/Command/routes.pm
+++ b/lib/Bailador/Command/routes.pm
@@ -1,4 +1,4 @@
-use v6;
+use v6.c;
 
 use Bailador::Command;
 

--- a/lib/Bailador/Command/tiny.pm
+++ b/lib/Bailador/Command/tiny.pm
@@ -1,4 +1,4 @@
-use v6;
+use v6.c;
 
 use Bailador::Command;
 

--- a/lib/Bailador/Command/watch.pm
+++ b/lib/Bailador/Command/watch.pm
@@ -1,8 +1,10 @@
-use v6;
+use v6.c;
 
-use Bailador::Command;
-use Bailador::CLI;
 use File::Find;
+
+use Bailador::CLI;
+use Bailador::Command;
+
 
 class Bailador::Command::watch does Bailador::Command {
     method run(:$app) {
@@ -76,5 +78,3 @@ class Bailador::Command::watch does Bailador::Command {
         return slip ($p.IO, slip find :dir($p), :type<dir>).grep: { !$seen{$_}++ };
     }
 }
-
-

--- a/lib/Bailador/Commands.pm
+++ b/lib/Bailador/Commands.pm
@@ -1,4 +1,4 @@
-use v6;
+use v6.c;
 
 use Bailador::Command::easy;
 use Bailador::Command::ogre;

--- a/lib/Bailador/Configuration.pm
+++ b/lib/Bailador/Configuration.pm
@@ -1,4 +1,4 @@
-use v6;
+use v6.c;
 
 use YAMLish;
 

--- a/lib/Bailador/ContentTypes.pm
+++ b/lib/Bailador/ContentTypes.pm
@@ -1,4 +1,4 @@
-use v6;
+use v6.c;
 
 class Bailador::ContentTypes {
     has %.mapping = (

--- a/lib/Bailador/Context.pm
+++ b/lib/Bailador/Context.pm
@@ -1,4 +1,5 @@
-use v6;
+use v6.c;
+
 use Bailador::Request;
 use Bailador::Response;
 

--- a/lib/Bailador/Exceptions.pm
+++ b/lib/Bailador/Exceptions.pm
@@ -1,4 +1,4 @@
-use v6;
+use v6.c;
 
 class X::Bailador::NoRouteFound is Exception {
     method message() {

--- a/lib/Bailador/Gradual.pm
+++ b/lib/Bailador/Gradual.pm
@@ -1,4 +1,5 @@
-use v6;
+use v6.c;
+
 use Bailador;
 use Bailador::Route::StaticFile;
 
@@ -29,4 +30,3 @@ get '/(.*)' => sub ($url) {
 
 my $files = Bailador::Route::StaticFile.new: directory => $rel_root.IO.child('static'), path => /(.*)/;
 app.add_route: $files;
-

--- a/lib/Bailador/LogAdapter.pm
+++ b/lib/Bailador/LogAdapter.pm
@@ -1,4 +1,4 @@
-use v6;
+use v6.c;
 
 use Log::Any::Adapter;
 

--- a/lib/Bailador/Request.pm
+++ b/lib/Bailador/Request.pm
@@ -1,5 +1,7 @@
 use v6.c;
+
 use HTTP::MultiPartParser;
+
 use Bailador::Request::Multipart;
 
 class Bailador::Request {

--- a/lib/Bailador/Request/Multipart.pm
+++ b/lib/Bailador/Request/Multipart.pm
@@ -1,4 +1,5 @@
-use v6;
+use v6.c;
+
 class Bailador::Request::Multipart {
     ## Content-Disposition: form-data; name="file"; filename="xxx.png"
     ## Content-Type: image/png

--- a/lib/Bailador/Response.pm
+++ b/lib/Bailador/Response.pm
@@ -1,4 +1,5 @@
-use v6;
+use v6.c;
+
 use URI::Escape;
 
 class Bailador::Response {

--- a/lib/Bailador/Route.pm
+++ b/lib/Bailador/Route.pm
@@ -1,7 +1,7 @@
-use v6;
+use v6.c;
 
-use Bailador::Request;
 use Bailador::Exceptions;
+use Bailador::Request;
 
 class Bailador::Route {
     subset HttpMethod of Str where {$_ eq any <GET PUT POST HEAD PUT DELETE TRACE OPTIONS CONNECT PATCH> }

--- a/lib/Bailador/Route/StaticFile.pm
+++ b/lib/Bailador/Route/StaticFile.pm
@@ -1,4 +1,4 @@
-use v6;
+use v6.c;
 
 use Bailador::Route;
 

--- a/lib/Bailador/Sessions.pm
+++ b/lib/Bailador/Sessions.pm
@@ -1,13 +1,13 @@
-use v6;
+use v6.c;
 
 use Digest;
 use Digest::HMAC;
 use Log::Any;
 
 use Bailador::Configuration;
-use Bailador::Sessions::Store;
 use Bailador::Request;
 use Bailador::Response;
+use Bailador::Sessions::Store;
 
 class Bailador::Sessions {
     has Bailador::Configuration $!config;

--- a/lib/Bailador/Sessions/Store.pm
+++ b/lib/Bailador/Sessions/Store.pm
@@ -1,4 +1,4 @@
-use v6;
+use v6.c;
 
 role Bailador::Sessions::Store {
     method store-session(Str $session-id, Hash $session) { ... }

--- a/lib/Bailador/Sessions/Store/Memory.pm
+++ b/lib/Bailador/Sessions/Store/Memory.pm
@@ -1,4 +1,4 @@
-use v6;
+use v6.c;
 
 use Bailador::Sessions::Store;
 

--- a/lib/Bailador/Template/Mojo.pm
+++ b/lib/Bailador/Template/Mojo.pm
@@ -1,6 +1,8 @@
 use v6.c;
-use Bailador::Template;
+
 use Template::Mojo;
+
+use Bailador::Template;
 
 class Bailador::Template::Mojo does Bailador::Template {
     has %.template-cache;

--- a/lib/Bailador/Template/Mustache.pm
+++ b/lib/Bailador/Template/Mustache.pm
@@ -1,4 +1,5 @@
 use v6.c;
+
 use Bailador::Template;
 
 class Bailador::Template::Mustache does Bailador::Template {

--- a/lib/Bailador/Test.pm
+++ b/lib/Bailador/Test.pm
@@ -1,8 +1,11 @@
-use v6;
+use v6.c;
+
 use Test;
+use URI;
+
 use Bailador;
 use Bailador::Request;
-use URI;
+
 
 unit module Bailador::Test;
 

--- a/t/00-lint.t
+++ b/t/00-lint.t
@@ -1,12 +1,15 @@
-use v6;
-use lib 'lib';
-use Test;
+use v6.c;
+
 use Path::Iterator;
+use Test;
+
+use lib 'lib';
+
 
 constant AUTHOR = ?%*ENV<AUTHOR_TESTING>;
 
 if AUTHOR {
-    # check for use v6;
+    # check for use v6.c;
     my @dirs = '.';
     for Path::Iterator.skip-vcs.ext(rx/ ^ ( 'p' <[lm]> 6? | t ) $ /).in(@dirs) -> $file {
         my @lines = $file.IO.lines;
@@ -24,4 +27,3 @@ else {
      skip-rest "Skipping author test";
      exit;
 }
-

--- a/t/00-load.t
+++ b/t/00-load.t
@@ -1,7 +1,8 @@
-use v6;
+use v6.c;
+
+use Test;
 
 use lib 'lib';
-use Test;
 
 plan 1;
 

--- a/t/00-test-meta.t
+++ b/t/00-test-meta.t
@@ -1,6 +1,9 @@
-use v6;
-use lib 'lib';
+use v6.c;
+
 use Test;
+
+use lib 'lib';
+
 plan 1;
 
 constant AUTHOR = ?%*ENV<AUTHOR_TESTING>;

--- a/t/00-tidy.t
+++ b/t/00-tidy.t
@@ -1,7 +1,9 @@
-use v6;
-use lib 'lib';
-use Test;
+use v6.c;
+
 use Path::Iterator;
+use Test;
+
+use lib 'lib';
 
 constant AUTHOR = ?%*ENV<AUTHOR_TESTING>;
 
@@ -24,4 +26,3 @@ else {
      skip-rest "Skipping author test";
      exit;
 }
-

--- a/t/01-OO-route-existence.t
+++ b/t/01-OO-route-existence.t
@@ -1,5 +1,7 @@
-use v6;
+use v6.c;
+
 use Test;
+
 use Bailador::Test;
 
 plan 9 + 9 + 9;

--- a/t/01-route-existence.t
+++ b/t/01-route-existence.t
@@ -1,5 +1,7 @@
-use v6;
+use v6.c;
+
 use Test;
+
 use Bailador;
 use Bailador::Test;
 
@@ -62,5 +64,3 @@ is-deeply get-psgi-response('POST', 'http://127.0.0.1:9876/f?text=bar', 'text=fo
 is-deeply get-psgi-response('POST', 'http://127.0.0.1:9876/g?text=bar', 'text=foo'), [200, ["Content-Type" => "text/html"], Any], 'content_type';  # ???
 is-deeply get-psgi-response('POST', 'http://127.0.0.1:9876/h?text=bar', 'text=foo'), [200, ["Content-Type" => "text/html"], Any], 'content_length';  # ???
 is-deeply get-psgi-response('POST', 'http://127.0.0.1:9876/i?text=bar', 'text=foo'), [200, ["Content-Type" => "text/html"], 'text=foo'], 'body';
-
-

--- a/t/02-request.t
+++ b/t/02-request.t
@@ -1,5 +1,7 @@
 use v6.c;
+
 use Test;
+
 use Bailador;
 use Bailador::Test;
 

--- a/t/03-OO-response-content.t
+++ b/t/03-OO-response-content.t
@@ -1,5 +1,7 @@
-use v6;
+use v6.c;
+
 use Test;
+
 use Bailador::App;
 use Bailador::Test;
 

--- a/t/03-response-content.t
+++ b/t/03-response-content.t
@@ -1,5 +1,7 @@
-use v6;
+use v6.c;
+
 use Test;
+
 use Bailador;
 use Bailador::Test;
 

--- a/t/04-01-templates.t
+++ b/t/04-01-templates.t
@@ -1,8 +1,11 @@
-use v6;
+use v6.c;
+
 use Test;
+
 use Bailador;
-Bailador::import;
 use Bailador::Test;
+
+Bailador::import;
 
 plan 9;
 

--- a/t/04-02-templates.t
+++ b/t/04-02-templates.t
@@ -1,11 +1,11 @@
-use v6;
+use v6.c;
 
 use Test;
 
 use Bailador;
+use Bailador::Test;
 
 Bailador::import;
-use Bailador::Test;
 
 plan 8;
 

--- a/t/04-OO-templates-mustache.t
+++ b/t/04-OO-templates-mustache.t
@@ -1,9 +1,11 @@
-use v6;
+use v6.c;
+
 use Test;
+
 use Bailador::App;
+use Bailador::Template::Mustache;
 use Bailador::Test;
 
-use Bailador::Template::Mustache;
 
 plan 3;
 

--- a/t/04-OO-templates.t
+++ b/t/04-OO-templates.t
@@ -1,5 +1,7 @@
-use v6;
+use v6.c;
+
 use Test;
+
 use Bailador::App;
 use Bailador::Test;
 

--- a/t/04-templates-mustache.t
+++ b/t/04-templates-mustache.t
@@ -1,10 +1,12 @@
-use v6;
+use v6.c;
+
 use Test;
+
 use Bailador;
-Bailador::import;
+use Bailador::Template::Mustache;
 use Bailador::Test;
 
-use Bailador::Template::Mustache;
+Bailador::import;
 
 plan 6;
 

--- a/t/04-templates.t
+++ b/t/04-templates.t
@@ -1,8 +1,10 @@
-use v6;
+use v6.c;
+
 use Test;
 use Bailador;
-Bailador::import;
 use Bailador::Test;
+
+Bailador::import;
 
 plan 9;
 

--- a/t/05-post-content.t
+++ b/t/05-post-content.t
@@ -1,5 +1,7 @@
-use v6;
+use v6.c;
+
 use Test;
+
 use Bailador;
 use Bailador::Test;
 

--- a/t/06-OO-cookies.t
+++ b/t/06-OO-cookies.t
@@ -1,5 +1,7 @@
-use v6;
+use v6.c;
+
 use Test;
+
 use Bailador::App;
 use Bailador::Test;
 

--- a/t/06-cookies.t
+++ b/t/06-cookies.t
@@ -1,5 +1,7 @@
-use v6;
+use v6.c;
+
 use Test;
+
 use Bailador;
 use Bailador::Test;
 

--- a/t/07-OO-errors.t
+++ b/t/07-OO-errors.t
@@ -1,5 +1,7 @@
-use v6;
+use v6.c;
+
 use Test;
+
 use Bailador::App;
 use Bailador::Test;
 

--- a/t/07-errors.t
+++ b/t/07-errors.t
@@ -1,5 +1,7 @@
-use v6;
+use v6.c;
+
 use Test;
+
 use Bailador;
 use Bailador::Test;
 
@@ -66,4 +68,3 @@ subtest {
 
 # vim: expandtab
 # vim: tabstop=4
-

--- a/t/08-OO-sessions.t
+++ b/t/08-OO-sessions.t
@@ -1,5 +1,7 @@
-use v6;
+use v6.c;
+
 use Test;
+
 use Bailador::App;
 use Bailador::Test;
 

--- a/t/08-sessions.t
+++ b/t/08-sessions.t
@@ -1,5 +1,7 @@
-use v6;
+use v6.c;
+
 use Test;
+
 use Bailador;
 use Bailador::Test;
 

--- a/t/09-OO-nested-routes.t
+++ b/t/09-OO-nested-routes.t
@@ -1,5 +1,7 @@
-use v6;
+use v6.c;
+
 use Test;
+
 use Bailador::App;
 use Bailador::Route;
 use Bailador::Test;
@@ -73,4 +75,3 @@ is-deeply $response, [200, [:Content-Type("text/html")], "logged out"] , "logged
 # get the login page again, because we're not logged in -> catch all again
 $response = get-psgi-response($app, 'GET', '/app/logout', http_cookie => "$session-cookie-name=$session-id");
 is-deeply $response, [200, [:Content-Type("text/html")], "this is the login page / catch all route"], "logout 2nd time - catchall";
-

--- a/t/09-prefix.t
+++ b/t/09-prefix.t
@@ -1,7 +1,9 @@
-use v6;
+use v6.c;
+
 use Test;
-use Bailador::Test;
+
 use Bailador;
+use Bailador::Test;
 
 plan 3;
 
@@ -95,4 +97,3 @@ subtest {
     is($prefixone-execution , 0 , 'prefix /xyz/:foo executed 2 times');
     is($prefixtwo-execution , 0 , 'prefix /xyz/:foo/next executed 4 times');
 };
-

--- a/t/10-request-multipart.t
+++ b/t/10-request-multipart.t
@@ -1,6 +1,8 @@
-use v6;
-use Bailador::Request::Multipart;
+use v6.c;
+
 use Test;
+
+use Bailador::Request::Multipart;
 
 plan 2;
 
@@ -37,4 +39,3 @@ subtest {
     is-deeply $multipart.content, $content, 'content';
     is $multipart.size, 6, 'content size';
 }
-

--- a/t/11-error-templates.t
+++ b/t/11-error-templates.t
@@ -1,8 +1,11 @@
-use v6;
+use v6.c;;
+
 use Test;
+
 use Bailador;
-Bailador::import;
 use Bailador::Test;
+
+Bailador::import;
 
 plan 8;
 
@@ -58,4 +61,3 @@ subtest {
     is-deeply %resp<response>, [500, ["Content-Type" => "text/html;charset=UTF-8"], 'muerte' ], '500 - with error template';
     like %resp<err>, rx:s/something/, 'stderr';
 }
-

--- a/t/12-duplicate.t
+++ b/t/12-duplicate.t
@@ -1,5 +1,7 @@
-use v6;
+use v6.c;
+
 use Test;
+
 use Bailador;
 use Bailador::Test;
 
@@ -21,4 +23,3 @@ try {
     }
 
 }
-

--- a/t/13-configuration.t
+++ b/t/13-configuration.t
@@ -1,6 +1,7 @@
 use v6.c;
 
 use Test;
+
 use Bailador;
 use Bailador::Test;
 

--- a/t/20-cli.t
+++ b/t/20-cli.t
@@ -1,8 +1,9 @@
-use v6;
+use v6.c;
+
 use File::Temp;
+use Test;
 
 use lib 'lib','t/lib';
-use Test;
 use Helpers;
 
 plan 4;

--- a/t/30-examples-api.t
+++ b/t/30-examples-api.t
@@ -1,7 +1,9 @@
-use v6;
-use Test;
-use Bailador::Test;
+use v6.c;
+
 use JSON::Fast;
+use Test;
+
+use Bailador::Test;
 
 plan 1;
 
@@ -22,6 +24,3 @@ subtest {
         courses => ['Perl', 'Web Development'],
     };
 }, '/';
-
-
-

--- a/t/30-examples-app.t
+++ b/t/30-examples-app.t
@@ -1,5 +1,7 @@
-use v6;
+use v6.c;
+
 use Test;
+
 use Bailador::Test;
 
 plan 12;

--- a/t/30-examples-echo.t
+++ b/t/30-examples-echo.t
@@ -1,5 +1,7 @@
-use v6;
+use v6.c;
+
 use Test;
+
 use Bailador::Test;
 
 plan 3;
@@ -30,5 +32,3 @@ subtest {
     is-deeply %data<response>, [200, ["Content-Type" => "text/html"], "echo via POST: Foo Bar"], 'route GET /';
     is %data<err>, '';
 }, '/';
-
-

--- a/t/30-examples-gradual.t
+++ b/t/30-examples-gradual.t
@@ -1,5 +1,7 @@
-use v6;
+use v6.c;
+
 use Test;
+
 use Bailador::Test;
 
 plan 6;

--- a/t/30-examples-pastebin.t
+++ b/t/30-examples-pastebin.t
@@ -1,7 +1,9 @@
-use v6;
-use Test;
-use Bailador::Test;
+use v6.c;
+
 use File::Directory::Tree;
+use Test;
+
+use Bailador::Test;
 
 plan 2;
 
@@ -45,4 +47,3 @@ subtest {
 }, 'paste';
 
 rmtree 'data';
-

--- a/t/30-examples-postapp.t
+++ b/t/30-examples-postapp.t
@@ -1,5 +1,7 @@
-use v6;
+use v6.c;
+
 use Test;
+
 use Bailador::Test;
 
 plan 2;
@@ -21,6 +23,3 @@ subtest {
     is-deeply %data<response>, [200, ["Content-Type" => "text/html"], ["\{:answer(\"42\"), :text(\"Foo Bar\")}", Any, Any]], 'route POST /';
     is %data<err>, '';
 }, '/';
-
-
-

--- a/t/apps/app.pl6
+++ b/t/apps/app.pl6
@@ -1,6 +1,6 @@
 #!/usr/bin/env perl6
 
-use v6;
+use v6.c;
 use lib 'lib';
 use Bailador;
 

--- a/t/lib/Helpers.pm6
+++ b/t/lib/Helpers.pm6
@@ -1,4 +1,5 @@
-use v6;
+use v6.c;
+
 unit module Test::Helpers;
 
 sub wait-port(int $port, Str $host='0.0.0.0', :$sleep=0.1, int :$times=600) is export {


### PR DESCRIPTION
A _small_ PR, to propose a convention about imports, inspired by Django projects. Clean imports should be : 
```perl6
use v6.c;

## External modules, sorted alphabetically
use HTTP::Easy::PSGI;
use Log::Any;
...

## Related modules to Bailador, sorted alphabetically
use Bailador::Configuration;
use Bailador::Sessions;
...
```
Just my 2 cents. 💲 