### PR TITLE
Runs Bailador t/ tests under Ducky.

### DIFF
--- a/ducky/README.md
+++ b/ducky/README.md
@@ -1,0 +1,20 @@
+# SYNOPSIS
+
+Runs Bailador t/ tests under [Ducky](https://github.com/melezhik/ducky)
+
+# INSTALL
+
+    $ git clone https://github.com/melezhik/ducky.git
+    $ PATH=$PWD/ducky:$PATH # add ducky.bash to the system PATH
+
+# Run tests
+
+    $ cd ducky/
+    $ docker pull melezhik/alpine-perl6
+    $ docker run --name bailador -itd  -v $PWD:/var/ducky melezhik/alpine-perl6
+    $ ducky.bash bailador
+
+# Author
+
+Alexey Melezhik
+

--- a/ducky/README.md
+++ b/ducky/README.md
@@ -1,14 +1,17 @@
 # SYNOPSIS
 
-Runs Bailador t/ tests under [Ducky](https://github.com/melezhik/ducky)
+Runs Bailador `t/` tests under [Ducky](https://github.com/melezhik/ducky).
 
 # INSTALL
 
+    # install ducky first
     $ git clone https://github.com/melezhik/ducky.git
     $ PATH=$PWD/ducky:$PATH # add ducky.bash to the system PATH
 
 # Run tests
 
+    # then run Bailador tests against running docker container
+    # tests are described at ducky/ducky.json file
     $ cd ducky/
     $ docker pull melezhik/alpine-perl6
     $ docker run --name bailador -itd  -v $PWD:/var/ducky melezhik/alpine-perl6

--- a/ducky/ducky.json
+++ b/ducky/ducky.json
@@ -1,0 +1,58 @@
+[
+
+  {
+    "task" : "install git",
+    "plugin" : "package-generic",
+    "data" : {
+        "list" : "git"
+    }
+  },
+  {
+    "task" : "install zef modules",
+    "plugin" : "bash",
+    "data" : {
+        "command" : "zef install Path::Iterator TAP::Harness",
+        "debug" : true
+    }
+  },
+  {
+    "task" : "remove bailador scource code directory",
+    "plugin" : "directory",
+    "data" : {
+        "path" : "/var/bailador",
+        "action" : "delete"
+    }
+  },
+  {
+    "task" : "create bailador scource code directory",
+    "plugin" : "directory",
+    "data" : {
+        "path" : "/var/bailador",
+        "action" : "create"
+    }
+  },
+  {
+    "task" : "checkout bailador source code",
+    "plugin" : "bash",
+    "data" : {
+        "command" : "git clone https://github.com/Bailador/Bailador.git /var/bailador"
+    }
+  },
+  {
+    "task" : "installs bailador dependencies",
+    "plugin" : "bash",
+    "data" : {
+        "command" : "cd /var/bailador && zef install . --deps-only"
+    }
+  },
+  {
+    "task" : "run t/ tests",
+    "plugin" : "bash",
+    "data" : {
+        "command" : "cd /var/bailador && prove6 -l",
+        "envvars" : {
+          "PATH" : "/root/.rakudobrew/moar-nom/install/share/perl6/site/bin:$PATH"
+        }
+    }
+  }
+]


### PR DESCRIPTION
Hi Bailador devs! You may try to run `t/` tests under running docker containers with the help of [Ducky](https://github.com/melezhik/ducky).
Yet another way to test code changes right from the working laptop ...

Here is the example ascii cast - https://asciinema.org/a/gasGt2WJx4UZ6KfWrPH7sO1Ha 


TODO: 

* check code from local git repo rather then from GH, to enable "pre-commit" tests.
* add more (integration) tests, rather then just `t/`
* tests for different platforms ( it only requires to change docker container, something different from alpine-perl6 )

