### PR TITLE
Add missing fat comma (fat arrow) to prefix docs

### DIFF
--- a/doc/README.md
+++ b/doc/README.md
@@ -221,7 +221,7 @@ The prefix sets up a [Nested Route](#nested-routes). All other routes that will 
 
 ```Perl6
     prefix "/foo" => sub {
-        prefix-enter sub {
+        prefix-enter => sub {
             ... something that returns True or False ...
         }
         get "/bar" => sub { ... }


### PR DESCRIPTION
The example code for prefix was missing the fat comma/fat arrow in the prefix-enter part. Added it