### PR TITLE
[RFC] Accesse and error logging

### DIFF
--- a/lib/Bailador/Configuration.pm
+++ b/lib/Bailador/Configuration.pm
@@ -41,6 +41,16 @@ class Bailador::Configuration {
     ## LOGGING
     has Str $.log-format is rw = '\d (\s) \m';
     has @.log-filter is rw     = ('severity' => '>=warning');
+    # Specify the access log format
+    # An empty string means no logging
+    has Str $.log-access-format is rw
+      where * ~~ '' | 'common' | 'combined' | 'bailador'
+      = '';
+    # has $.log-access-file = ''; # or log-access-output?
+    has Str $.log-error-format is rw
+      where * ~~ '' | 'simple'
+      = '';
+    # has $.log-error-file = ''; # TODO: use this variable to determine if log should be used
 
     method !variants($filename) {
         my @pieces = $filename.split('.');

--- a/lib/Bailador/LogFormatter.pm6
+++ b/lib/Bailador/LogFormatter.pm6
@@ -1,0 +1,92 @@
+use v6.c;
+
+# Log::Any v 0.9.4 introduces extra-fields.
+use Log::Any::Formatter:ver('0.9.4');
+
+# class A2-Formatter is Log::Any::Formatter {
+#   my @res;
+#   has $.format;
+#   method format( :$date-time, :$msg!, :$category!, :$severity!, :%extra-fields ) {
+#     $!format.format( %extra-fields, @res, 0, $date-time, DateTime.now );
+#   }
+# }
+
+class Bailador::LogFormatter is Log::Any::Formatter {
+  has $.format = 'apache-combined';
+  has $!backend;
+
+  use Log::Any::Formatter;
+  submethod TWEAK {
+    given $!format {
+      when 'combined' {
+        # Combined apache log format "%h %l %u %t \"%r\" %>s %b \"%{Referer}i\" \"%{User-agent}i\""
+        $!backend = Log::Any::FormatterBuiltIN.new(
+          :format( '\e{h} \e{l} \e{u} [\e{t}] "\e{r}" \e{s} \e{b} "\e{Referer}" \e{User-agent}' )
+        );
+      }
+      when 'common' {
+        # Common apache log format "%h %l %u %t \"%r\" %>s %b"
+        $!backend = Log::Any::FormatterBuiltIN.new(
+          :format(  '\e{h} \e{l} \e{u} [\e{t}] \e{r} \e{s} \e{b}' )
+        );
+      }
+      default {
+        $!backend = Log::Any::FormatterBuiltIN.new(
+          # Serving GET /test HTTP/1.0 with 200
+          :format( 'Serving \e{r} with \e{s}' )
+        );
+      }
+    }
+  }
+
+  method format( :$date-time, :$msg!, :$category!, :$severity!, :%extra-fields ) {
+    my %data;
+    my $request =
+      %extra-fields<REQUEST_METHOD> ~ ' '
+      ~ %extra-fields<PATH_INFO> // %extra-fields<REQUEST_URI>.split('?')[0] ~ ' '
+      ~ %extra-fields<SERVER_PROTOCOL>;
+
+    sub dateTime-to-Str( DateTime:D $date-time ) {
+      my @month = <Jan Feb Mar Apr May Jun Jul Aug Sep Oct Nov Dec>;
+      with $date-time {
+        sprintf '%02d/%s/%04d:%02d:%02d:%02d %02d',
+          .day, @month[.month-1], .year, .hour, .minute, .second, .offset-in-hours * 100
+      }
+    }
+
+    given $!format {
+      when 'combined' {
+        %data = Hash.new((
+          :h(%extra-fields<SERVER_NAME> // '-' ),
+          :l('-'), # RFC 1413 identity of the client, highly unreliable (https://httpd.apache.org/docs/1.3/logs.html)
+          :u( %extra-fields<REMOTE_USER> // '-' ), #
+          :t( &dateTime-to-Str( DateTime.now ) ),
+          :r( $request),
+          :s( %extra-fields<HTTP_CODE> // '-'),
+          :b( '-' ), # todo, response content size, '-' if null
+          :Referer( %extra-fields<HTTP_REFERER> // '-' ),
+          :User-agent( %extra-fields<HTTP_USER_AGENT> // '-' ),
+        ));
+      }
+      when 'common' {
+        %data = Hash.new((
+          :h(%extra-fields<SERVER_NAME> // '-' ),
+          :l('-'), # RFC 1413 identity of the client, highly unreliable (https://httpd.apache.org/docs/1.3/logs.html)
+          :u( %extra-fields<REMOTE_USER> // '-' ), # todo: user
+          :t( dateTime-to-Str( DateTime.now ) ),
+          :r($request),
+          :s(%extra-fields<HTTP_CODE> // '-'),
+          :b( '-' ), # todo, response content size, '-' if null
+        ));
+      }
+      default {
+        %data = Hash.new( ( :r($request), :s(%extra-fields<HTTP_CODE>) ) );
+      }
+    }
+
+    $!backend.format(
+      :date-time(''), :msg(''), :category(''), :severity(''),
+      :extra-fields( %data )
+    );
+  }
+}


### PR DESCRIPTION
Hello,

I started to work on the logging system to allow logging http accesses and errors in the manner of apache/nginx servers with their corresponding format (common, combined).

According to a Bailador task (#107), psw specification defines an error stream. I don't know if this is to be used for printing on the server side (error file, stderr) or to be sent to the HTTP client.

In a classical architecture, accesses are logged by apache and errors are sent to apache by the CGI.
In Bailador architecture, I suppose the server is the Psw backend, and Bailador acts as the CGI, so should I continue this development in Bailador or should I wrote it in the backend?

Please note that it still need some more work before a possible merge (like specifying the log file, testing, …).