### PR TITLE
Export the from-json method from JSON::Fast.

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,3 +1,5 @@
+    - Export the from-json method from JOSN::Fast
+
 0.0.14 2017.11.07
     - Improvment of the logging functionality in Bailador - Thanks to jsimonet++
     - Ticket #151, #278, #277

--- a/doc/README.md
+++ b/doc/README.md
@@ -32,6 +32,7 @@
         - [`template(Str $template-name, *@params)`](#templatestr-template-name-params)
         - [`session()`](#session)
         - [`to-json()`](#to-json)
+        - [`from-json()`](#from-json)
         - [`render($content)`](#render-content)
         - [`render(Int :$status, Str :$type is copy, :$content is copy)`](#renderint-status-str-type-is-copy-content-is-copy)
         - [`render-file(Str $filename, Str :$mime-type)`](#render-filestr-filename-strmime-type)
@@ -285,6 +286,10 @@ Check out the [session example](../examples/sessions/sessions.pl6).
 Converts your data into JSON format using JSON::Fast.
 
 Check out the [api example](../examples/api/api.pl6) and the corresponding [test case](../t/30-examples-api.t).
+
+### `from-json()`
+
+Converts your data from JSON format using JSON::Fast.
 
 #### `render($content)`
 #### `render(Int :$status, Str :$type is copy, :$content is copy)`

--- a/lib/Bailador.pm
+++ b/lib/Bailador.pm
@@ -15,6 +15,7 @@ my $container;
 
 my package EXPORT::DEFAULT {
     OUR::{'&to-json'} := &to-json;
+    OUR::{'&from-json'} := &from-json;
 }
 
 multi sub app {


### PR DESCRIPTION
It's confusing for users to only export the `to-json` method.