### PR TITLE
undo change of path for win distro

### DIFF
--- a/lib/Bailador/App.pm
+++ b/lib/Bailador/App.pm
@@ -125,9 +125,9 @@ class Bailador::App does Bailador::Routing {
                 my $parent = $*PROGRAM.parent.resolve;
                 $app-root = $parent.basename eq 'bin' ?? $parent.parent !! $parent;
             }
-            if $*DISTRO.is-win {
-                $app-root.=subst(/\\/, '', :x(1));
-            }
+            # if $*DISTRO.is-win {
+                # $app-root.=subst(/\\/, '', :x(1));
+            # }
             self.location($app-root.Str);
         }
         return $!location;


### PR DESCRIPTION
> my $s = 'C:\Users\quest\Desktop\t\robotix';
C:\Users\quest\Desktop\t\robotix
> $s .= subst(/\\/, '', :x(1));
C:Users\quest\Desktop\t\robotix

C:Users is not correct path