### PR TITLE
Adapt to rename of Path::Iterator to Path::Finder

### DIFF
--- a/META6.json
+++ b/META6.json
@@ -31,7 +31,7 @@
     "HTTP::Status",
     "JSON::Fast",
     "Log::Any",
-    "Path::Iterator",
+    "Path::Finder",
     "Template::Mojo",
     "Template::Mustache",
     "Terminal::ANSIColor",

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -14,7 +14,7 @@ install:
   - rakudobrew build zef
   - cd %APPVEYOR_BUILD_FOLDER%
   - zef install Test::META
-  - zef --force install Path::Iterator
+  - zef --force install Path::Finder
 # https://github.com/labster/p6-file-directory-tree/issues/12
   - zef --force install File::Directory::Tree
   - zef --force install Log::Any

--- a/t/00-lint.t
+++ b/t/00-lint.t
@@ -39,7 +39,7 @@ my &by = sub ($a, $b) {
 if AUTHOR {
     # check for use v6.c;
     my @dirs = '.';
-    for Path::Finder.skip-vcs.ext(rx/ ^ ( 'p' <[lm]> 6? | t ) $ /).in(@dirs) -> $file {
+    for find(@dirs, :skip-vcs, :ext(rx/ ^ ( 'p' <[lm]> 6? | t ) $ /)) -> $file {
         my @lines = $file.lines;
         my @modules;
         for @lines -> $line {

--- a/t/00-lint.t
+++ b/t/00-lint.t
@@ -1,7 +1,7 @@
 use v6.c;
 use lib 'lib';
 
-use Path::Iterator;
+use Path::Finder;
 use Test;
 
 constant AUTHOR = ?%*ENV<AUTHOR_TESTING>;
@@ -39,8 +39,8 @@ my &by = sub ($a, $b) {
 if AUTHOR {
     # check for use v6.c;
     my @dirs = '.';
-    for Path::Iterator.skip-vcs.ext(rx/ ^ ( 'p' <[lm]> 6? | t ) $ /).in(@dirs) -> $file {
-        my @lines = $file.IO.lines;
+    for Path::Finder.skip-vcs.ext(rx/ ^ ( 'p' <[lm]> 6? | t ) $ /).in(@dirs) -> $file {
+        my @lines = $file.lines;
         my @modules;
         for @lines -> $line {
             next if $line eq '#!/usr/bin/env perl6'|'';

--- a/t/00-tidy.t
+++ b/t/00-tidy.t
@@ -10,11 +10,10 @@ if AUTHOR {
     # check for trailing spaces
     # check for tabs
     my @dirs = '.';
-    for Path::Finder.skip-vcs.skip-dir('.precomp').ext(rx/ ^ ( 'p' <[lm]> 6? | t ) $ /).in(@dirs) -> $file {
+    for find(@dirs, :ext(rx/ ^ ( 'p' <[lm]> 6? | t ) $ /), :skip-vcs, :skip-dir<.precomp>) -> $file {
         check_tidy($file);
     }
-    for Path::Finder.skip-vcs.skip-dir('.precomp').in('examples') -> $file {
-        next if not $file.f;
+    for find('examples', :file, :skip-vcs, :skip-dir('.precomp')) -> $file {
         check_tidy($file);
     }
     check_tidy('bin/bailador');

--- a/t/00-tidy.t
+++ b/t/00-tidy.t
@@ -1,7 +1,7 @@
 use v6.c;
 use lib 'lib';
 
-use Path::Iterator;
+use Path::Finder;
 use Test;
 
 constant AUTHOR = ?%*ENV<AUTHOR_TESTING>;
@@ -10,10 +10,10 @@ if AUTHOR {
     # check for trailing spaces
     # check for tabs
     my @dirs = '.';
-    for Path::Iterator.skip-vcs.skip-dir('.precomp').ext(rx/ ^ ( 'p' <[lm]> 6? | t ) $ /).in(@dirs) -> $file {
+    for Path::Finder.skip-vcs.skip-dir('.precomp').ext(rx/ ^ ( 'p' <[lm]> 6? | t ) $ /).in(@dirs) -> $file {
         check_tidy($file);
     }
-    for Path::Iterator.skip-vcs.skip-dir('.precomp').in('examples') -> $file {
+    for Path::Finder.skip-vcs.skip-dir('.precomp').in('examples') -> $file {
         next if not $file.f;
         check_tidy($file);
     }


### PR DESCRIPTION
I recently renamed `Path::Iterator` to `Path::Finder` in the mistaken belief that no one was using my entirely undocumented module. Sorry about the breakage.